### PR TITLE
Guarantee a space between converted list elements.

### DIFF
--- a/lib/org/converter/converter.js
+++ b/lib/org/converter/converter.js
@@ -79,7 +79,10 @@ Converter.prototype = {
   },
 
   convertNode: function (node, recordHeader) {
-    var childText = node.children ? this.convertNodes(node.children, recordHeader) : "";
+    var childText = (
+      node.children
+        ? this.convertNodes(node.children, recordHeader, node.joiner)
+        : "");
     var text;
 
     var auxData = this.computeAuxDataForNode(node);
@@ -225,10 +228,10 @@ Converter.prototype = {
     return escapedText;
   },
 
-  convertNodes: function (nodes, recordHeader) {
+  convertNodes: function (nodes, recordHeader, joiner) {
     return nodes.map(function (node) {
       return this.convertNode(node, recordHeader);
-    }, this).join("");
+    }, this).join(joiner || "");
   },
 
   getNodeTextContent: function (node) {

--- a/lib/org/node.js
+++ b/lib/org/node.js
@@ -57,7 +57,9 @@ Node.define("header", function (node, options) {
 Node.define("orderedList");
 Node.define("unorderedList");
 Node.define("definitionList");
-Node.define("listElement");
+Node.define("listElement", function (node, options) {
+  node.joiner = ' ';
+});
 Node.define("paragraph");
 Node.define("preformatted");
 Node.define("table");


### PR DESCRIPTION
Hi, Masafumi.  This is an attempt I made to solve Issue #4.   While it seems to solve many cases of missing spaces in my documents, there are other kinds of cases, so maybe some more broad approach could solve more issues at once.  So, I'm not sure this is acceptable (and beware, I'm still a Javascript newbee).

In particular, in the generated HTML, I see a new space before `<table>`, when the beginning table immediately follows the end of another table.  That space should ideally not be there.
